### PR TITLE
Add error matchers for known warning or error strings

### DIFF
--- a/.github/elixir.json
+++ b/.github/elixir.json
@@ -11,6 +11,21 @@
           "message": 7
         }
       ]
+    },
+    {
+      "owner": "elixir-warning",
+      "pattern": [
+        {
+          "regexp": "^(warning: (.*))$",
+          "message": 2
+        },
+        {
+          "regexp": "^(  )((.:)?[^:]*):(\\d+)(:(\\d+))?$",
+          "file": 2,
+          "line": 4,
+          "column": 6
+        }
+      ]
     }
   ]
 }

--- a/.github/elixir.json
+++ b/.github/elixir.json
@@ -1,0 +1,16 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "elixir",
+      "pattern": [
+        {
+          "regexp": "^(\\*\\* \\(.*\\) )?((.:)?[^:]*):(\\d+)(:(\\d+))?: (.*)$",
+          "file": 2,
+          "line": 4,
+          "column": 6,
+          "message": 7
+        }
+      ]
+    }
+  ]
+}

--- a/src/setup-elixir.js
+++ b/src/setup-elixir.js
@@ -38,6 +38,9 @@ async function main() {
 
   if (installRebar) await exec('mix local.rebar --force')
   if (installHex) await exec('mix local.hex --force')
+
+  const matchersPath = path.join(__dirname, '..', '.github');
+  console.log(`##[add-matcher]${path.join(matchersPath, 'elixir.json')}`);
 }
 
 function checkPlatform() {


### PR DESCRIPTION
This add error matchers for known warning or error strings and report these inline.

![image](https://user-images.githubusercontent.com/1911813/69694860-49fba480-10a8-11ea-941a-487e9a9d2750.png)


Also works for with credo in flycheck format:

    mix credo --format flycheck

![image](https://user-images.githubusercontent.com/1911813/69694904-6dbeea80-10a8-11ea-9f3d-73817923bb0c.png)

Sample: https://github.com/mijailr/actions_sample/commit/a23f73ba43313897e97376800f01e67a14c1c7af#annotation_8344189283441892
