### PR TITLE
Fetch OTP release based on ImageOS environment variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   otp-version:
     description: Version range or exact version of OTP to use
   experimental-otp:
-    description: Whether to use experimental builds of OTP (images have not yet been fully tested include ubuntu-16.04, ubuntu-18.04, ubuntu-20.04)
+    description: Whether to use experimental builds of OTP (images that have not yet been fully tested include ubuntu-16.04, ubuntu-18.04, ubuntu-20.04)
     default: false
   install-hex:
     description: Whether to install Hex

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
     description: Version range or exact version of Elixir to use
   otp-version:
     description: Version range or exact version of OTP to use
+  experimental-otp:
+    description: Whether to use experimental builds of OTP (images have not yet been fully tested include ubuntu-16.04, ubuntu-18.04, ubuntu-20.04)
+    default: false
   install-hex:
     description: Whether to install Hex
     default: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -3321,12 +3321,16 @@ async function main() {
     elixirSpec,
     otpVersion
   )
-  const osVersion = getOSVersion()
 
   let installHex = core.getInput('install-hex')
   installHex = installHex == null ? 'true' : installHex
+
   let installRebar = core.getInput('install-rebar')
   installRebar = installRebar == null ? 'true' : installRebar
+
+  const experimentalOTP = core.getInput('experimental-otp')
+  const osVersion =
+    experimentalOTP === 'true' ? getRunnerOSVersion() : 'ubuntu-14.04'
 
   console.log(`##[group]Installing OTP ${otpVersion} - built on ${osVersion}`)
   await installOTP(otpVersion, osVersion)
@@ -3359,7 +3363,7 @@ async function getOtpVersion(spec) {
   return getVersionFromSpec(spec, await getOtpVersions()) || spec
 }
 
-function getOSVersion() {
+function getRunnerOSVersion(experimentalOTP) {
   const mapToUbuntuVersion = {
     ubuntu16: 'ubuntu-16.04',
     ubuntu18: 'ubuntu-18.04',

--- a/dist/index.js
+++ b/dist/index.js
@@ -2955,9 +2955,9 @@ async function installElixir(version, otpMajor) {
  *
  * @param {string} version
  */
-async function installOTP(version) {
+async function installOTP(version, osVersion) {
   if (process.platform === 'linux') {
-    await exec(__webpack_require__.ab + "install-otp", [version])
+    await exec(__webpack_require__.ab + "install-otp", [version, osVersion])
     return
   }
 
@@ -3321,14 +3321,15 @@ async function main() {
     elixirSpec,
     otpVersion
   )
+  const osVersion = getOSVersion()
 
   let installHex = core.getInput('install-hex')
   installHex = installHex == null ? 'true' : installHex
   let installRebar = core.getInput('install-rebar')
   installRebar = installRebar == null ? 'true' : installRebar
 
-  console.log(`##[group]Installing OTP ${otpVersion}`)
-  await installOTP(otpVersion)
+  console.log(`##[group]Installing OTP ${otpVersion} - built on ${osVersion}`)
+  await installOTP(otpVersion, osVersion)
   console.log(`##[endgroup]`)
 
   console.log(`##[group]Installing Elixir ${elixirVersion}`)
@@ -3344,6 +3345,7 @@ async function main() {
   console.log(`##[add-matcher]${path.join(matchersPath, 'elixir.json')}`)
   core.setOutput('otp-version', otpVersion)
   core.setOutput('elixir-version', elixirVersion)
+  core.setOutput('osVersion', osVersion)
 }
 
 function checkPlatform() {
@@ -3355,6 +3357,16 @@ function checkPlatform() {
 
 async function getOtpVersion(spec) {
   return getVersionFromSpec(spec, await getOtpVersions()) || spec
+}
+
+function getOSVersion() {
+  const mapToUbuntuVersion = {
+    ubuntu16: 'ubuntu-16.04',
+    ubuntu18: 'ubuntu-18.04',
+    ubuntu20: 'ubuntu-20.04',
+  }
+
+  return mapToUbuntuVersion[process.env.ImageOS] || 'ubuntu-18.04'
 }
 
 exports.getElixirVersion = getElixirVersion

--- a/dist/install-otp
+++ b/dist/install-otp
@@ -4,7 +4,7 @@ set -eo pipefail
 
 cd $RUNNER_TEMP
 
-wget -q -O otp.tar.gz https://repo.hex.pm/builds/otp/ubuntu-14.04/OTP-${1}.tar.gz
+wget -q -O otp.tar.gz https://repo.hex.pm/builds/otp/${2}/OTP-${1}.tar.gz
 mkdir -p .setup-elixir/otp
 tar zxf otp.tar.gz -C .setup-elixir/otp --strip-components=1
 rm otp.tar.gz

--- a/src/install-otp
+++ b/src/install-otp
@@ -4,7 +4,7 @@ set -eo pipefail
 
 cd $RUNNER_TEMP
 
-wget -q -O otp.tar.gz https://repo.hex.pm/builds/otp/ubuntu-14.04/OTP-${1}.tar.gz
+wget -q -O otp.tar.gz https://repo.hex.pm/builds/otp/${2}/OTP-${1}.tar.gz
 mkdir -p .setup-elixir/otp
 tar zxf otp.tar.gz -C .setup-elixir/otp --strip-components=1
 rm otp.tar.gz

--- a/src/installer.js
+++ b/src/installer.js
@@ -22,9 +22,9 @@ async function installElixir(version, otpMajor) {
  *
  * @param {string} version
  */
-async function installOTP(version) {
+async function installOTP(version, osVersion) {
   if (process.platform === 'linux') {
-    await exec(path.join(__dirname, 'install-otp'), [version])
+    await exec(path.join(__dirname, 'install-otp'), [version, osVersion])
     return
   }
 

--- a/src/setup-elixir.js
+++ b/src/setup-elixir.js
@@ -23,12 +23,16 @@ async function main() {
     elixirSpec,
     otpVersion
   )
-  const osVersion = getOSVersion()
 
   let installHex = core.getInput('install-hex')
   installHex = installHex == null ? 'true' : installHex
+
   let installRebar = core.getInput('install-rebar')
   installRebar = installRebar == null ? 'true' : installRebar
+
+  const experimentalOTP = core.getInput('experimental-otp')
+  const osVersion =
+    experimentalOTP === 'true' ? getRunnerOSVersion() : 'ubuntu-14.04'
 
   console.log(`##[group]Installing OTP ${otpVersion} - built on ${osVersion}`)
   await installOTP(otpVersion, osVersion)
@@ -61,7 +65,7 @@ async function getOtpVersion(spec) {
   return getVersionFromSpec(spec, await getOtpVersions()) || spec
 }
 
-function getOSVersion() {
+function getRunnerOSVersion(experimentalOTP) {
   const mapToUbuntuVersion = {
     ubuntu16: 'ubuntu-16.04',
     ubuntu18: 'ubuntu-18.04',

--- a/src/setup-elixir.js
+++ b/src/setup-elixir.js
@@ -23,14 +23,15 @@ async function main() {
     elixirSpec,
     otpVersion
   )
+  const osVersion = getOSVersion()
 
   let installHex = core.getInput('install-hex')
   installHex = installHex == null ? 'true' : installHex
   let installRebar = core.getInput('install-rebar')
   installRebar = installRebar == null ? 'true' : installRebar
 
-  console.log(`##[group]Installing OTP ${otpVersion}`)
-  await installOTP(otpVersion)
+  console.log(`##[group]Installing OTP ${otpVersion} - built on ${osVersion}`)
+  await installOTP(otpVersion, osVersion)
   console.log(`##[endgroup]`)
 
   console.log(`##[group]Installing Elixir ${elixirVersion}`)
@@ -46,6 +47,7 @@ async function main() {
   console.log(`##[add-matcher]${path.join(matchersPath, 'elixir.json')}`)
   core.setOutput('otp-version', otpVersion)
   core.setOutput('elixir-version', elixirVersion)
+  core.setOutput('osVersion', osVersion)
 }
 
 function checkPlatform() {
@@ -57,6 +59,16 @@ function checkPlatform() {
 
 async function getOtpVersion(spec) {
   return getVersionFromSpec(spec, await getOtpVersions()) || spec
+}
+
+function getOSVersion() {
+  const mapToUbuntuVersion = {
+    ubuntu16: 'ubuntu-16.04',
+    ubuntu18: 'ubuntu-18.04',
+    ubuntu20: 'ubuntu-20.04',
+  }
+
+  return mapToUbuntuVersion[process.env.ImageOS] || 'ubuntu-18.04'
 }
 
 exports.getElixirVersion = getElixirVersion


### PR DESCRIPTION
Once https://github.com/hexpm/bob/pull/68 is merged we'll probably want to fetch correct OTP build based on the vm running the action.

Obviously the checks will be failing until bob the builder builds those OTP versions.